### PR TITLE
Debug `yy`, `dd`, and modularized code slightly

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,35 @@
+{
+  "short_name": "SlateVim",
+  "name": "SlateVim",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "logo192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "logo512.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff",
+  "permissions" : [
+    "http://*/*",
+    "https://*/*",
+    "clipboardRead",
+    "clipboardWrite",
+    "storage"
+  ],
+  "web_accessible_resources" : [
+    "public/execCommand.js"
+  ]
+}

--- a/src/App.js
+++ b/src/App.js
@@ -6,16 +6,17 @@ import { createEditor, Transforms, Editor, Text, Path } from "slate";
 import { Slate, Editable, withReact } from "slate-react";
 import { withHistory } from "slate-history";
 
-// Custom components
+// Custom
 import Header from "./components/Header";
+import NormalEditor from "./components/NormalEditor";
+import InsertEditor from "./components/InsertEditor";
+import { btnStyle, paraStyle } from "./styles/tailwindStyles";
+import { INSERT_MODE, initialValue } from "./utils/variables";
 
 const App = () => {
-  const editor = useMemo(() => withHistory(withReact(createEditor()), []));
+  const editor = useMemo(() => withReact(createEditor()), []);
   const [value, setValue] = useState(initialValue);
   const [mode, setMode] = useState(INSERT_MODE);
-
-  const [keyString, setKeyString] = useState("");
-  const [clipboard, setClipboard] = useState("");
 
   const onModeButtonClick = (event) => {
     setMode(event.target.value);
@@ -23,7 +24,7 @@ const App = () => {
 
   return (
     <div>
-      <Header mode={mode} paraStyle={paraStyle} />
+      <Header />
       <div className="container rounded bg-gray-200 p-2 w-1/6 mx-auto text-base text-center m-4">
         <div className="flex space-x-4">
           <button
@@ -47,132 +48,12 @@ const App = () => {
         <span className="text-red-500">{mode.toUpperCase()}</span> mode.
       </p>
       {mode === INSERT_MODE ? (
-        <Slate
-          editor={editor}
-          value={value}
-          onChange={(value) => setValue(value)}
-        >
-          <Editable
-            autoFocus
-            className="box-border rounded h-80 w-1/3 mx-auto bg-black p-6 text-white overflow-y-auto"
-          />
-        </Slate>
+        <InsertEditor value={value} setValue={(value) => setValue(value)} />
       ) : (
-        <Slate
-          editor={editor}
-          value={value}
-          onChange={(value) => setValue(value)}
-        >
-          <Editable
-            className="box-border rounded h-80 w-1/3 mx-auto bg-black p-6 text-white overflow-y-auto"
-            autoFocus
-            onKeyDown={(event) => {
-              if (event.key === "d") {
-                if (keyString === "d") {
-                  event.preventDefault();
-                  // Move selection to start of line
-                  Transforms.move(editor, { unit: "line", reverse: "true" });
-                  const start = editor.selection.anchor;
-                  console.log(start);
-                  // Move cursor to end of line
-                  Transforms.move(editor, { unit: "line" });
-                  const end = editor.selection.anchor;
-                  console.log(end);
-                  // Select text from start of line to end of line
-                  Transforms.select(editor, {
-                    anchor: start,
-                    focus: { path: end.path, offset: getIndexLastCharOfLine() },
-                  });
-                  document.execCommand("copy");
-                  Transforms.delete(editor);
-                  setKeyString("");
-                  return false;
-                }
-                event.preventDefault();
-                setKeyString("d");
-              }
-              if (event.key === "y") {
-                if (keyString === "y") {
-                  event.preventDefault();
-                  // Move selection to start of line
-                  Transforms.move(editor, { unit: "line", reverse: "true" });
-                  const start = editor.selection.anchor;
-                  console.log(start);
-                  // Move cursor to end of line
-                  Transforms.move(editor, { unit: "line" });
-                  const end = editor.selection.anchor;
-                  console.log(end);
-                  // Select text from start of line to end of line
-                  Transforms.select(editor, {
-                    anchor: start,
-                    focus: { path: end.path, offset: getIndexLastCharOfLine() },
-                  });
-                  document.execCommand("copy");
-                  setKeyString("");
-                  return false;
-                }
-                event.preventDefault();
-                setKeyString("y");
-              }
-              if (event.key === "j") {
-              }
-            }}
-          />
-          <p className={`${paraStyle}`}>
-            Current registered half-command:{" "}
-            {keyString ? (
-              <kbd className="bg-gray-200 p-1 rounded">{keyString}</kbd>
-            ) : null}
-          </p>
-        </Slate>
+        <NormalEditor value={value} setValue={(value) => setValue(value)} />
       )}
     </div>
   );
 };
 
 export default App;
-
-// Get index of last character of line, as on displayed DOM, not in Slate editor
-const getIndexLastCharOfLine = () => {
-  const selection = window.getSelection();
-  const range = selection.getRangeAt(0);
-  const caretIndex = range.startOffset;
-  const rect = range.getBoundingClientRect();
-  const container = range.startContainer;
-  const lastIndex = container.length;
-
-  for (let i = caretIndex; i < lastIndex; i++) {
-    const rangeTest = document.createRange();
-    rangeTest.setStart(container, i);
-    const rectTest = rangeTest.getBoundingClientRect();
-    // if the y is different it means the test range is in a different line
-    if (rectTest.y !== rect.y) return i - 1;
-  }
-
-  return lastIndex;
-};
-
-// Some Constants
-const LINE_MAX_CHAR = 83;
-
-// Vim Modes
-const INSERT_MODE = "insert";
-const NORMAL_MODE = "normal";
-
-// Initial document value(s), [Node]
-const initialValue = [
-  {
-    type: "paragraph",
-    children: [
-      {
-        text:
-          "In Insert Mode, you can edit plaintext, just as you would in Vim!",
-      },
-    ],
-  },
-];
-
-const btnStyle =
-  "flex-1 bg-gray-100 hover:bg-gray-300 text-black font-bold py-2 px-4 rounded";
-
-const paraStyle = "container w-5/12 mx-auto text-base text-center m-4";

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,6 +1,8 @@
 import React from "react";
 
-const Header = ({ mode, paraStyle }) => {
+import { paraStyle } from "../styles/tailwindStyles";
+
+const Header = () => {
   return (
     <div className={`${paraStyle} text-justify`}>
       <p className="m-2">

--- a/src/components/InsertEditor.js
+++ b/src/components/InsertEditor.js
@@ -1,0 +1,25 @@
+import React, { useMemo, useState } from "react";
+import { createEditor } from "slate";
+import { Slate, Editable, withReact } from "slate-react";
+
+import { editorStyle } from "../styles/tailwindStyles";
+
+const InsertEditor = (props) => {
+  const editor = useMemo(() => withReact(createEditor()), []);
+  const [value, setValue] = useState(props.value);
+
+  return (
+    <Slate
+      editor={editor}
+      value={value}
+      onChange={(value) => {
+        setValue(value);
+        props.setValue(value);
+      }}
+    >
+      <Editable autoFocus className={`${editorStyle}`} />
+    </Slate>
+  );
+};
+
+export default InsertEditor;

--- a/src/components/NormalEditor.js
+++ b/src/components/NormalEditor.js
@@ -1,0 +1,207 @@
+import React, { useMemo, useState } from "react";
+import { createEditor, Transforms } from "slate";
+import { Slate, Editable, withReact } from "slate-react";
+import { withHistory } from "slate-history";
+
+import {
+  getIndexLastCharOfLine,
+  getIndexFirstCharOfLine,
+} from "../utils/cursorMethods";
+import { paste } from "../utils/textEditingMethods";
+import { paraStyle, editorStyle } from "../styles/tailwindStyles";
+
+const NormalEditor = (props) => {
+  const editor = useMemo(() => withHistory(withReact(createEditor())), []);
+  const [value, setValue] = useState(props.value);
+  const [keyString, setKeyString] = useState("");
+
+  return (
+    <Slate
+      editor={editor}
+      value={value}
+      onChange={(value) => {
+        setValue(value);
+        props.setValue(value);
+      }}
+    >
+      <Editable
+        className={`${editorStyle}`}
+        autoFocus
+        onKeyDown={(event) => {
+          // Delete (cut) line
+          if (keyString === "d") {
+            if (event.key === "d") {
+              event.preventDefault();
+              // Move selection to start of line
+              Transforms.move(editor, { unit: "line", reverse: "true" });
+              const start = editor.selection.anchor;
+              // Move cursor to end of line
+              Transforms.move(editor, { unit: "line" });
+              const end = editor.selection.anchor;
+              // If no more text in editor, don't do anything
+              if (start.offset === end.offset) return false;
+              // Select text from start of line to end of line
+              Transforms.select(editor, {
+                anchor: { path: start.path, offset: getIndexFirstCharOfLine() },
+                focus: { path: end.path, offset: getIndexLastCharOfLine() },
+              });
+              document.execCommand("cut");
+              setKeyString("");
+              return false;
+            } else if (event.key === "0") {
+              event.preventDefault();
+              // Get original cursor position
+              const cursor = editor.selection.anchor;
+              // Move selection to start of line
+              Transforms.move(editor, { unit: "line", reverse: "true" });
+              const start = editor.selection.anchor;
+              // If no more text in editor, don't do anything
+              if (start.offset === cursor.offset) return false;
+              // Select text from start of line to cursor
+              Transforms.select(editor, {
+                anchor: { path: start.path, offset: getIndexFirstCharOfLine() },
+                focus: { path: cursor.path, offset: cursor.offset },
+              });
+              document.execCommand("cut");
+              setKeyString("");
+              return false;
+            } else if (event.key === "$") {
+              event.preventDefault();
+              // Get original cursor position
+              const cursor = editor.selection.anchor;
+              // Move selection to end of line
+              Transforms.move(editor, { unit: "line" });
+              const end = editor.selection.anchor;
+              // If no more text in editor, don't do anything
+              if (end.offset === cursor.offset) return false;
+              // Select text from start of line to cursor
+              Transforms.select(editor, {
+                anchor: { path: cursor.path, offset: cursor.offset },
+                focus: { path: end.path, offset: getIndexLastCharOfLine() },
+              });
+              document.execCommand("cut");
+              setKeyString("");
+              return false;
+            }
+          }
+          if (event.key === "d") {
+            event.preventDefault();
+            setKeyString("d");
+            return false;
+          }
+          // Yank (copy) line
+          if (keyString === "y") {
+            if (event.key === "y") {
+              event.preventDefault();
+              // Get original cursor position
+              const originalPosition = editor.selection;
+              // Move selection to start of line
+              Transforms.move(editor, { unit: "line", reverse: "true" });
+              const start = editor.selection.anchor;
+              // Move cursor to end of line
+              Transforms.move(editor, { unit: "line" });
+              const end = editor.selection.anchor;
+              // If no more text in editor, don't do anything
+              if (start.offset === end.offset) return false;
+              // Select text from start of line to end of line
+              Transforms.select(editor, {
+                anchor: { path: start.path, offset: getIndexFirstCharOfLine() },
+                focus: { path: end.path, offset: getIndexLastCharOfLine() },
+              });
+              document.execCommand("copy");
+              // Move cursor back to original position
+              Transforms.select(editor, originalPosition);
+              setKeyString("");
+              return false;
+            } else if (event.key === "0") {
+              event.preventDefault();
+              // Get original cursor position
+              const originalPosition = editor.selection;
+              // Get cursor position
+              const cursor = editor.selection.anchor;
+              // Move selection to start of line
+              Transforms.move(editor, { unit: "line", reverse: "true" });
+              const start = editor.selection.anchor;
+              // If no more text in editor, don't do anything
+              if (start.offset === cursor.offset) return false;
+              // Select text from start of line to cursor
+              Transforms.select(editor, {
+                anchor: { path: start.path, offset: getIndexFirstCharOfLine() },
+                focus: { path: cursor.path, offset: cursor.offset },
+              });
+              document.execCommand("copy");
+              // Move cursor back to original position
+              Transforms.select(editor, originalPosition);
+              setKeyString("");
+              return false;
+            } else if (event.key === "$") {
+              event.preventDefault();
+              // Get original cursor position
+              const originalPosition = editor.selection;
+              // Get current cursor position
+              const cursor = editor.selection.anchor;
+              // Move selection to end of line
+              Transforms.move(editor, { unit: "line" });
+              const end = editor.selection.anchor;
+              // If no more text in editor, don't do anything
+              if (end.offset === cursor.offset) return false;
+              // Select text from start of line to cursor
+              Transforms.select(editor, {
+                anchor: { path: cursor.path, offset: cursor.offset },
+                focus: { path: end.path, offset: getIndexLastCharOfLine() },
+              });
+              document.execCommand("copy");
+              // Move cursor back to original position
+              Transforms.select(editor, originalPosition);
+              setKeyString("");
+              return false;
+            }
+          }
+          if (event.key === "y") {
+            event.preventDefault();
+            setKeyString("y");
+            return false;
+          }
+          // Undo
+          if (event.key === "u") {
+            event.preventDefault();
+            editor.undo();
+            return false;
+          }
+          // Redo
+          if (event.ctrlKey) {
+            if (event.key === "r") {
+              event.preventDefault();
+              editor.redo();
+              return false;
+            }
+            event.preventDefault();
+            setKeyString("ctrl");
+          }
+          // Paste at cursor
+          if (event.key === "p") {
+            event.preventDefault();
+            paste(editor);
+            return false;
+          }
+          // Paste before cursor
+          if (event.key === "P") {
+            event.preventDefault();
+            // Move cursor to one character before
+            Transforms.move(editor, { unit: "character", reverse: "true" });
+            paste(editor);
+            return false;
+          }
+        }}
+      />
+      <p className={`${paraStyle}`}>
+        Current registered half-command:{" "}
+        {keyString ? (
+          <kbd className="bg-gray-200 p-1 rounded">{keyString}</kbd>
+        ) : null}
+      </p>
+    </Slate>
+  );
+};
+
+export default NormalEditor;

--- a/src/styles/tailwindStyles.js
+++ b/src/styles/tailwindStyles.js
@@ -1,0 +1,7 @@
+export const btnStyle =
+  "flex-1 bg-gray-100 hover:bg-gray-300 text-black font-bold py-2 px-4 rounded";
+
+export const paraStyle = "container w-5/12 mx-auto text-base text-center m-4";
+
+export const editorStyle =
+  "box-border rounded h-80 w-1/3 mx-auto bg-black p-6 text-white overflow-y-auto";

--- a/src/utils/cursorMethods.js
+++ b/src/utils/cursorMethods.js
@@ -1,0 +1,38 @@
+// Get index of last character of line, as on displayed DOM, not in Slate editor
+export const getIndexLastCharOfLine = () => {
+  const selection = window.getSelection();
+  const range = selection.getRangeAt(0);
+  const caretIndex = range.startOffset;
+  const rect = range.getBoundingClientRect();
+  const container = range.startContainer;
+  const lastIndex = container.length;
+
+  for (let i = caretIndex; i < lastIndex; i++) {
+    const rangeTest = document.createRange();
+    rangeTest.setStart(container, i);
+    const rectTest = rangeTest.getBoundingClientRect();
+    // if the y is different it means the test range is in a different line
+    if (rectTest.y !== rect.y) return i - 1;
+  }
+
+  return lastIndex;
+};
+
+export const getIndexFirstCharOfLine = () => {
+  const selection = window.getSelection();
+  const range = selection.getRangeAt(0);
+  const caretIndex = range.startOffset;
+  const rect = range.getBoundingClientRect();
+  const container = range.startContainer;
+  const firstIndex = 0;
+
+  for (let i = caretIndex; i > 0; i--) {
+    const rangeTest = document.createRange();
+    rangeTest.setStart(container, i);
+    const rectTest = rangeTest.getBoundingClientRect();
+    // if the y is different it means the test range is in a different line
+    if (rectTest.y !== rect.y) return i;
+  }
+
+  return firstIndex;
+};

--- a/src/utils/textEditingMethods.js
+++ b/src/utils/textEditingMethods.js
@@ -1,0 +1,12 @@
+import { Transforms } from "slate";
+
+export const paste = (editor) => {
+  navigator.clipboard
+    .readText()
+    .then((text) => Transforms.insertText(editor, text))
+    .catch((err) => console.log(err));
+};
+
+export const copy = (text) => {
+  navigator.clipboard.writeText(text);
+};

--- a/src/utils/variables.js
+++ b/src/utils/variables.js
@@ -1,0 +1,19 @@
+// Some Constants
+export const LINE_MAX_CHAR = 83;
+
+// Vim Modes
+export const INSERT_MODE = "insert";
+export const NORMAL_MODE = "normal";
+
+// Initial document value(s), [Node]
+export const initialValue = [
+  {
+    type: "paragraph",
+    children: [
+      {
+        text:
+          "In Insert Mode, you can edit plaintext, just as you would in Vim!",
+      },
+    ],
+  },
+];


### PR DESCRIPTION
Three main things:
  1. Separated NormalEditor and InsertEditor into two different files with
Slate wrappers, but passed the same `value` prop from `App`, and `onChange`
also modifies `App`'s `value` state.
  2. Added a few more Normal mode commands like `p`, `P`, `d0`, `y0`, `d$`,
`y$`, `u`, `ctrl+r`.
  3. Debug `yy` and `dd`'s line-determination scheme.

There is one main issue with the implementation of `u` and `ctrl+r`, that
is, undo and redo. That is, `editor.undo()` and `editor.redo()` seem to be
affected by the structure of Slate nodes, though I have not checked this
yet. So the current behavior of deleting a line and using `editor.undo()`
results in some sort of undefined behavior.